### PR TITLE
chore: generate firebase configs during build

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,29 @@ If you clone this repository, run:
 npm install
 ```
 
+### Firebase configuration
+
+The build relies on environment variables to generate Firebase config files that stay out of version control. Before running `npm run build`, define the following variables in your shell (or in your hosting provider):
+
+```bash
+export PUBLIC_FIREBASE_API_KEY="AIzaSyA8vJUZ7443oyptRcOJs7Ig_gbrwCSB5bA"
+export PUBLIC_FIREBASE_AUTH_DOMAIN="hernandez-photo.firebaseapp.com"
+export PUBLIC_FIREBASE_PROJECT_ID="hernandez-photo"
+export PUBLIC_FIREBASE_STORAGE_BUCKET="hernandez-photo.appspot.com"
+export PUBLIC_FIREBASE_MESSAGING_SENDER_ID="312479713819"
+export PUBLIC_FIREBASE_APP_ID="1:312479713819:web:4788b418257451097a06be"
+export PUBLIC_FIREBASE_MEASUREMENT_ID="G-WN7Z0S51HW"
+export ADMIN_PHONE_ALLOWLIST="+18155011478,+13316451372"
+```
+
+The build script will then create `assets/js/firebase-config.js` and `admin/firebase-config.js` automatically:
+
+```bash
+npm run build
+```
+
+> The two generated files remain git-ignored; they only exist in the build output.
+
 ### Files
 
 - `index.html` - Main website file

--- a/package.json
+++ b/package.json
@@ -3,6 +3,8 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
+    "create-configs": "node scripts/create-firebase-config.mjs",
+    "build": "npm run create-configs && npm run build-css",
     "build-css": "tailwindcss -i ./src/input.css -o ./styles.css --minify",
     "watch-css": "tailwindcss -i ./src/input.css -o ./styles.css --watch",
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/scripts/create-firebase-config.mjs
+++ b/scripts/create-firebase-config.mjs
@@ -1,0 +1,103 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const currentDir = dirname(fileURLToPath(import.meta.url));
+const rootDir = resolve(currentDir, '..');
+
+/**
+ * Resolve variable names to environment values and ensure none are missing.
+ * @param {string[]} keys
+ * @returns {Record<string, string>}
+ */
+function loadEnv(keys) {
+  const values = {};
+  const missing = [];
+
+  keys.forEach((key) => {
+    const value = process.env[key];
+    if (typeof value === 'string' && value.trim().length > 0) {
+      values[key] = value.trim();
+    } else {
+      missing.push(key);
+    }
+  });
+
+  if (missing.length) {
+    throw new Error(
+      `Missing required environment variables: ${missing.join(', ')}`
+    );
+  }
+
+  return values;
+}
+
+/**
+ * Create the firebase config string written to disk.
+ * @param {Record<string, string>} envMap
+ * @param {string[]} allowedUploaders
+ */
+function generateConfig(envMap, allowedUploaders) {
+  const config = {
+    apiKey: envMap.PUBLIC_FIREBASE_API_KEY,
+    authDomain: envMap.PUBLIC_FIREBASE_AUTH_DOMAIN,
+    projectId: envMap.PUBLIC_FIREBASE_PROJECT_ID,
+    storageBucket: envMap.PUBLIC_FIREBASE_STORAGE_BUCKET,
+    messagingSenderId: envMap.PUBLIC_FIREBASE_MESSAGING_SENDER_ID,
+    appId: envMap.PUBLIC_FIREBASE_APP_ID,
+  };
+
+  if (envMap.PUBLIC_FIREBASE_MEASUREMENT_ID) {
+    config.measurementId = envMap.PUBLIC_FIREBASE_MEASUREMENT_ID;
+  }
+
+  const lines = [
+    '// Auto-generated during build. Do not edit manually.',
+    'window.firebaseConfig = ' + JSON.stringify(config, null, 2) + ';',
+  ];
+
+  lines.push(
+    'window.allowedUploaders = ' + JSON.stringify(allowedUploaders) + ';',
+    ''
+  );
+
+  return lines.join('\n');
+}
+
+function writeFile(targetPath, contents) {
+  mkdirSync(dirname(targetPath), { recursive: true });
+  writeFileSync(targetPath, contents, 'utf8');
+  // eslint-disable-next-line no-console
+  console.log(`Created ${targetPath.replace(rootDir + '/', '')}`);
+}
+
+function main() {
+  const envMap = loadEnv([
+    'PUBLIC_FIREBASE_API_KEY',
+    'PUBLIC_FIREBASE_AUTH_DOMAIN',
+    'PUBLIC_FIREBASE_PROJECT_ID',
+    'PUBLIC_FIREBASE_STORAGE_BUCKET',
+    'PUBLIC_FIREBASE_MESSAGING_SENDER_ID',
+    'PUBLIC_FIREBASE_APP_ID',
+    // optional but still load if present
+    'PUBLIC_FIREBASE_MEASUREMENT_ID',
+  ]);
+
+  const allowListRaw = process.env.ADMIN_PHONE_ALLOWLIST || '';
+  const allowedUploaders = allowListRaw
+    .split(',')
+    .map((value) => value.trim())
+    .filter(Boolean);
+
+  const output = generateConfig(envMap, allowedUploaders);
+
+  writeFile(resolve(rootDir, 'assets/js/firebase-config.js'), output);
+  writeFile(resolve(rootDir, 'admin/firebase-config.js'), output);
+}
+
+try {
+  main();
+} catch (error) {
+  console.error('[create-firebase-config] Failed:', error.message);
+  process.exitCode = 1;
+}


### PR DESCRIPTION
## Summary
- add build step to generate firebase config files from environment variables
- script writes both public and admin config files while keeping them gitignored
- document required environment variables and expose npm build entry point