### PR TITLE
chore: support dotenv for firebase configs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ yarn-error.log*
 # Firebase configuration (local only)
 admin/firebase-config.js
 assets/js/firebase-config.js
+
+.env

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "playwright": "^1.55.1"
       },
       "devDependencies": {
+        "dotenv": "^17.2.3",
         "tailwindcss": "^3.4.17"
       }
     },
@@ -364,6 +365,19 @@
       "integrity": "sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dotenv": {
+      "version": "17.2.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.3.tgz",
+      "integrity": "sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "homepage": "https://github.com/RazonIn4K/hernandezlandscapeservices#readme",
   "description": "",
   "devDependencies": {
+    "dotenv": "^17.2.3",
     "tailwindcss": "^3.4.17"
   },
   "dependencies": {

--- a/scripts/create-firebase-config.mjs
+++ b/scripts/create-firebase-config.mjs
@@ -1,6 +1,11 @@
 import { mkdirSync, writeFileSync } from 'node:fs';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import dotenv from 'dotenv';
+
+// Load environment variables from .env (if present)
+dotenv.config();
+
 
 const currentDir = dirname(fileURLToPath(import.meta.url));
 const rootDir = resolve(currentDir, '..');


### PR DESCRIPTION
## Summary
- load .env automatically before generating firebase configs
- add dotenv dev dependency and document .env ignore entry
