### PR TITLE
ci: gate deploys on media manifest drift (media:check)

### DIFF
--- a/.github/MAINTENANCE_PLAN.md
+++ b/.github/MAINTENANCE_PLAN.md
@@ -30,10 +30,14 @@ unexpectedly, check `Get-MpThreatDetection` and restore with
 2. **Instant-estimate lead handoff** — the `#quoteForm` estimator collects address /
    owner-verification / best-time fields that are silently discarded. Turn it into a
    prefill step for the real Web3Forms form. (PR: `fix/instant-estimate-leads`)
-3. **Reproducible gallery/media workflow** — one manifest + one command. Today:
-   `gallery.html` hardcodes cards, `static-gallery.js` hardcodes a second list, the
-   Python generators write fragments nobody assembles, and `scripts/optimize_media.py`
-   has absolute paths into the previous developer's Mac (`/Users/davidortiz/...`).
+3. **Reproducible gallery/media workflow** — DONE 2026-06-10 (PR #24): `media/gallery.json`
+   + `npm run media:update` regenerate the gallery.html cards, videos.html players,
+   homepage carousel data, and sitemap media entries between GENERATED markers;
+   `scripts/optimize_media.py` is repo-relative now. See `docs/MEDIA-WORKFLOW.md`.
+   CI also runs `npm run media:check` and fails the deploy on manifest/page drift.
+   Open follow-ups: the index.html 3-card grid and the videos.html VideoObject
+   JSON-LD are still hand-maintained; five tracked mp4s are 54-94 MB and should be
+   re-encoded with the optimizer settings (GitHub hard-fails files at 100 MB).
 4. **Verify billing artifacts before touching them** — `pricing.html` + `/pay/*` are
    website-care billing (Stripe payment links). Confirm account ownership/liveness
    in Stripe, then either add test coverage (and fix the success page's missing

--- a/.github/MAINTENANCE_PLAN.md
+++ b/.github/MAINTENANCE_PLAN.md
@@ -36,11 +36,16 @@ unexpectedly, check `Get-MpThreatDetection` and restore with
    `scripts/optimize_media.py` is repo-relative now. See `docs/MEDIA-WORKFLOW.md`.
    CI also runs `npm run media:check` and fails the deploy on manifest/page drift.
    Open follow-ups: the index.html 3-card grid and the videos.html VideoObject
-   JSON-LD are still hand-maintained; five mp4s (web_IMG_1095/1096/1229/1268/0434-1)
-   ship at phone-original bitrates, 27-51 MB each on disk (older 54-94 MB versions
-   remain in git history), with one file over GitHub's 50 MB warning line.
-   Re-encoding them to the optimizer settings (1280 max width, crf 23) roughly
-   halves total weight with no resolution loss.
+   JSON-LD are still hand-maintained. The five large mp4s
+   (web_IMG_1095/1096/1229/1268/0434-1, 27-51 MB) must be LEFT AS-IS: they are
+   already libx264 outputs near their h264 size floor, and a measured re-encode
+   at optimizer settings (2026-06-10) inflated them ~27% because reproducing
+   prior compression artifacts costs more bits (two clips are 10-bit HLG).
+   Only web_IMG_1229.mp4 crosses GitHub's 50 MB warn line; the hard limit is
+   100 MB. If size ever truly matters, the real levers are: encode fresh from
+   the raw iCloud .MOV sources recoverable from git history (e.g.
+   `git show '146ada2:iCloud Photos/IMG_1095.MOV' > raw.mov`), trim the
+   2.5-minute clips, or add an AV1/HEVC <source> with h264 fallback.
 4. **Verify billing artifacts before touching them** — `pricing.html` + `/pay/*` are
    website-care billing (Stripe payment links). Confirm account ownership/liveness
    in Stripe, then either add test coverage (and fix the success page's missing

--- a/.github/MAINTENANCE_PLAN.md
+++ b/.github/MAINTENANCE_PLAN.md
@@ -36,8 +36,11 @@ unexpectedly, check `Get-MpThreatDetection` and restore with
    `scripts/optimize_media.py` is repo-relative now. See `docs/MEDIA-WORKFLOW.md`.
    CI also runs `npm run media:check` and fails the deploy on manifest/page drift.
    Open follow-ups: the index.html 3-card grid and the videos.html VideoObject
-   JSON-LD are still hand-maintained; five tracked mp4s are 54-94 MB and should be
-   re-encoded with the optimizer settings (GitHub hard-fails files at 100 MB).
+   JSON-LD are still hand-maintained; five mp4s (web_IMG_1095/1096/1229/1268/0434-1)
+   ship at phone-original bitrates, 27-51 MB each on disk (older 54-94 MB versions
+   remain in git history), with one file over GitHub's 50 MB warning line.
+   Re-encoding them to the optimizer settings (1280 max width, crf 23) roughly
+   halves total weight with no resolution loss.
 4. **Verify billing artifacts before touching them** — `pricing.html` + `/pay/*` are
    website-care billing (Stripe payment links). Confirm account ownership/liveness
    in Stripe, then either add test coverage (and fix the success page's missing

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Install dependencies
         run: npm install
 
+      - name: Check generated media surfaces
+        run: npm run media:check
+
       - name: Install Playwright browser
         run: npx playwright install --with-deps chromium
 

--- a/docs/MEDIA-WORKFLOW.md
+++ b/docs/MEDIA-WORKFLOW.md
@@ -67,3 +67,7 @@ regenerates all the places that media appears, so the pages never drift apart.
   optimized output in `hernandez_images/` is committed.
 - `scripts/optimize_media.py` is optional and local-only; `npm run
   media:update` never requires it.
+- CI runs `npm run media:check` on every deploy and fails the build if any
+  generated region drifted from `media/gallery.json` (for example after a
+  hand edit inside the markers, or a manifest change committed without
+  regenerating). Fix by running `npm run media:update` and committing.

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "test:ci": "playwright test --reporter=dot",
     "dev": "npm run watch-css",
     "media:update": "node scripts/update-media.mjs",
+    "media:check": "node scripts/update-media.mjs --check",
     "submit-indexnow": "node scripts/submit-indexnow.mjs"
   },
   "repository": {

--- a/scripts/update-media.mjs
+++ b/scripts/update-media.mjs
@@ -3,6 +3,8 @@
  * update-media.mjs — regenerate every gallery/media surface from media/gallery.json.
  *
  * Usage: npm run media:update   (or: node scripts/update-media.mjs)
+ *        npm run media:check    (--check: validate + exit 1 on drift, write nothing;
+ *                                run by CI so a manifest/page mismatch fails the deploy)
  *
  * media/gallery.json is the single source of truth for gallery/carousel/video
  * media. This script:
@@ -29,6 +31,7 @@ import { fileURLToPath } from 'node:url';
 
 const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const MANIFEST_PATH = path.join(ROOT, 'media', 'gallery.json');
+const CHECK_MODE = process.argv.includes('--check');
 
 const MARKERS = {
   galleryPage: { start: '<!-- GALLERY:GENERATED:START -->', end: '<!-- GALLERY:GENERATED:END -->' },
@@ -40,6 +43,7 @@ const MARKERS = {
 
 const errors = [];
 const warnings = [];
+const drifted = [];
 const fail = (msg) => errors.push(msg);
 const warn = (msg) => warnings.push(msg);
 
@@ -318,6 +322,9 @@ function updateFile(relPath, transforms) {
   if (errors.length) return;
   if (updated === original) {
     console.log(`  ${relPath}: unchanged`);
+  } else if (CHECK_MODE) {
+    drifted.push(relPath);
+    console.log(`  ${relPath}: STALE (does not match media/gallery.json)`);
   } else {
     fs.writeFileSync(filePath, updated);
     console.log(`  ${relPath}: updated`);
@@ -350,4 +357,15 @@ if (errors.length) {
   process.exit(1);
 }
 for (const msg of warnings) console.warn(`  warning: ${msg}`);
-console.log('Done. Review the diff, then commit.');
+if (CHECK_MODE) {
+  if (drifted.length) {
+    console.error(
+      `Drift detected in ${drifted.length} file(s): generated regions do not match ` +
+      'media/gallery.json. Run `npm run media:update` and commit the result.'
+    );
+    process.exit(1);
+  }
+  console.log('All generated media surfaces match media/gallery.json.');
+} else {
+  console.log('Done. Review the diff, then commit.');
+}


### PR DESCRIPTION
Guardrails bundle: adds an npm run media:check step to the deploy workflow so deploys fail on media manifest drift, adds the --check mode to scripts/update-media.mjs, and corrects the media maintenance docs (oversized-video sizes; retracts the video re-encode recommendation after a measured regression).

Commits: 6e2f9c2, b32a0b6, fb2b3af